### PR TITLE
Add additional HasServer and HasClient instances for Throwing

### DIFF
--- a/src/Servant/Checked/Exceptions/Internal/Servant/Client.hs
+++ b/src/Servant/Checked/Exceptions/Internal/Servant/Client.hs
@@ -27,14 +27,13 @@ This module only exports 'HasClient' instances for 'Throws' and 'Throwing'.
 module Servant.Checked.Exceptions.Internal.Servant.Client where
 
 import Data.Proxy (Proxy(Proxy))
-import Servant.API (Verb, (:>))
+import Servant.API (Verb, (:>), (:<|>))
 import Servant.Client (HasClient(clientWithRoute, Client))
 import Servant.Common.Req (Req)
 
 import Servant.Checked.Exceptions.Internal.Envelope (Envelope)
 import Servant.Checked.Exceptions.Internal.Servant.API
-       (Throws, Throwing)
-import Servant.Checked.Exceptions.Internal.Util (Snoc)
+       (Throws, Throwing, ThrowingNonterminal)
 
 -- TODO: Make sure to also account for when headers are being used.
 
@@ -63,17 +62,33 @@ instance (HasClient (Verb method status ctypes (Envelope es a))) =>
   clientWithRoute Proxy =
     clientWithRoute (Proxy :: Proxy (Verb method status ctypes (Envelope es a)))
 
--- | When a @'Throws' e@ comes immediately after a @'Throwing' es@, 'Snoc' the
--- @e@ onto the @es@.
-instance (HasClient (Throwing (Snoc es e) :> api)) =>
-    HasClient (Throwing es :> Throws e :> api) where
+-- | When @'Throwing' es@ comes before ':<|>', push @'Throwing' es@ into each
+-- branch of the API.
+instance HasClient ((Throwing es :> api1) :<|> (Throwing es :> api2)) =>
+    HasClient (Throwing es :> (api1 :<|> api2)) where
 
-  type Client (Throwing es :> Throws e :> api) =
-    Client (Throwing (Snoc es e) :> api)
+  type Client (Throwing es :> (api1 :<|> api2)) =
+    Client ((Throwing es :> api1) :<|> (Throwing es :> api2))
 
   clientWithRoute
-    :: Proxy (Throwing es :> Throws e :> api)
+    :: Proxy (Throwing es :> (api1 :<|> api2))
     -> Req
-    -> Client (Throwing (Snoc es e) :> api)
-  clientWithRoute Proxy =
-    clientWithRoute (Proxy :: Proxy (Throwing (Snoc es e) :> api))
+    -> Client ((Throwing es :> api1) :<|> (Throwing es :> api2))
+  clientWithRoute _ =
+    clientWithRoute (Proxy :: Proxy ((Throwing es :> api1) :<|> (Throwing es :> api2)))
+
+-- | When a @'Throws' e@ comes immediately after a @'Throwing' es@, 'Snoc' the
+-- @e@ onto the @es@. Otherwise, if @'Throws' e@ comes before any other
+-- combinator, push it down so it is closer to the 'Verb'.
+instance HasClient (ThrowingNonterminal (Throwing es :> api :> apis)) =>
+    HasClient (Throwing es :> api :> apis) where
+
+  type Client (Throwing es :> api :> apis) =
+    Client (ThrowingNonterminal (Throwing es :> api :> apis))
+
+  clientWithRoute
+    :: Proxy (Throwing es :> api :> apis)
+    -> Req
+    -> Client (ThrowingNonterminal (Throwing es :> api :> apis))
+  clientWithRoute _ =
+    clientWithRoute (Proxy :: Proxy (ThrowingNonterminal (Throwing es :> api :> apis)))

--- a/src/Servant/Checked/Exceptions/Internal/Servant/Server.hs
+++ b/src/Servant/Checked/Exceptions/Internal/Servant/Server.hs
@@ -34,8 +34,7 @@ import Servant
 
 import Servant.Checked.Exceptions.Internal.Envelope (Envelope)
 import Servant.Checked.Exceptions.Internal.Servant.API
-       (Throws, Throwing)
-import Servant.Checked.Exceptions.Internal.Util (Snoc)
+       (Throws, Throwing, ThrowingNonterminal)
 
 -- TODO: Make sure to also account for when headers are being used.
 
@@ -82,14 +81,6 @@ instance HasServer ((Throwing es :> api1) :<|> (Throwing es :> api2)) context =>
     -> Delayed env (ServerT ((Throwing es :> api1) :<|> (Throwing es :> api2)) Handler)
     -> Router env
   route _ = route (Proxy :: Proxy ((Throwing es :> api1) :<|> (Throwing es :> api2)))
-
--- | Used by the 'HasServer' instance for @'Throwing' es ':>' api ':>' apis@ to
--- detect @'Throwing' es@ followed immediately by @'Throws' e@.
-type family ThrowingNonterminal api where
-  ThrowingNonterminal (Throwing es :> Throws e :> api) =
-    Throwing (Snoc es e) :> api
-  ThrowingNonterminal (Throwing es :> c :> api) =
-    c :> Throwing es :> api
 
 -- | When a @'Throws' e@ comes immediately after a @'Throwing' es@, 'Snoc' the
 -- @e@ onto the @es@. Otherwise, if @'Throws' e@ comes before any other


### PR DESCRIPTION
This PR adds `HasServer` and `HasClient` instances for `Throwing` to handle APIs that use `(:<|>)` as well as `Throwing` in positions that come earlier than immediately before the `Verb`, such as `Throws Err :> Capture "x" Integer :> Get '[JSON] Integer`.

The latter instance overlaps with the instance for `Throwing es :> Throws e :> api`, so a new closed type family, `ThrowingNonterminal`, disambiguates these two cases in a single instance. This avoids the need for overlapping instances, but the name is not the best. If you can come up with a better name, by all means, feel free to change it.

Full disclosure: I am new to working with servant combinators, so I don’t claim any of this is the right or best way to do things. Feedback and/or constructive criticism is appreciated!

Closes #6.