### PR TITLE
Needs GHC >= 8 because of semigroups

### DIFF
--- a/servant-checked-exceptions.cabal
+++ b/servant-checked-exceptions.cabal
@@ -33,7 +33,7 @@ library
                      , Servant.Checked.Exceptions.Internal.Servant.Server
                      , Servant.Checked.Exceptions.Internal.Union
                      , Servant.Checked.Exceptions.Internal.Util
-  build-depends:       base >= 4.8 && < 5
+  build-depends:       base >= 4.9 && < 5
                      , aeson
                      , bytestring
                      , deepseq


### PR DESCRIPTION
Another option would be to conditionally add semigroups as a dependency for older GHCs.

Thanks for this lib! I haven't gotten around to using it yet but I've really missed something like this when using plain servant.
