### PR TITLE
Bump version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,68 +29,41 @@ matrix:
   # are finished building.  Don't wait for the "allowed_failures" to finish.
   fast_finish: true
   include:
-  # We grab the appropriate GHC and cabal-install versions from hvr's PPA. See:
-  # - env: BUILD=cabal GHCVER=7.4.2 CABALVER=1.16 HAPPYVER=1.19.5 ALEXVER=3.1.7
-  #   compiler: ": #GHC 7.4.2"
-  #   addons: {apt: {packages: [cabal-install-1.16,ghc-7.4.2,happy-1.19.5,alex-3.1.7], sources: [hvr-ghc]}}
-
-  # - env: BUILD=cabal GHCVER=7.6.3 CABALVER=1.16 HAPPYVER=1.19.5 ALEXVER=3.1.7
-  #   compiler: ": #GHC 7.6.3"
-  #   addons: {apt: {packages: [cabal-install-1.16,ghc-7.6.3,happy-1.19.5,alex-3.1.7], sources: [hvr-ghc]}}
-
-  # - env: BUILD=cabal GHCVER=7.8.4 CABALVER=1.18 HAPPYVER=1.19.5 ALEXVER=3.1.7
-  #   compiler: ": #GHC 7.8.4"
-  #   addons: {apt: {packages: [cabal-install-1.18,ghc-7.8.4,happy-1.19.5,alex-3.1.7], sources: [hvr-ghc]}}
-
-  # - env: BUILD=cabal GHCVER=7.10.3 CABALVER=1.22 HAPPYVER=1.19.5 ALEXVER=3.1.7
-  #   compiler: ": #GHC 7.10.3"
-  #   addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.3,happy-1.19.5,alex-3.1.7], sources: [hvr-ghc]}}
-
   - env: BUILD=cabal GHCVER=8.0.2 CABALVER=1.24 HAPPYVER=1.19.5 ALEXVER=3.1.7
     compiler: ": #GHC 8.0.2"
     addons: {apt: {packages: [cabal-install-1.24,ghc-8.0.2,happy-1.19.5,alex-3.1.7], sources: [hvr-ghc]}}
 
-  # The Stack builds. We can pass in arbitrary Stack arguments via the ARGS
-  # variable, such as using --stack-yaml to point to a different file.
-  # - env: BUILD=stack ARGS="--resolver lts-6"
-  #   compiler: ": #stack 7.10.3 (lts-6)"
-  #   addons: {apt: {packages: [ghc-7.10.3,libgmp-dev], sources: [hvr-ghc]}}
+  - env: BUILD=cabal GHCVER=8.2.2 CABALVER=2.0 HAPPYVER=1.19.5 ALEXVER=3.1.7
+    compiler: ": #GHC 8.2.2"
+    addons: {apt: {packages: [cabal-install-2.0,ghc-8.2.2,happy-1.19.5,alex-3.1.7], sources: [hvr-ghc]}}
 
-  # - env: BUILD=stack ARGS="--resolver lts-7"
-  #   compiler: ": #stack 8.0.1 (lts-7)"
-  #   addons: {apt: {packages: [ghc-8.0.1,libgmp-dev], sources: [hvr-ghc]}}
+  # Build with the newest GHC and cabal-install. This is an accepted failure,
+  # see below.
+  - env: BUILD=cabal GHCVER=head  CABALVER=head HAPPYVER=1.19.5 ALEXVER=3.1.7
+    compiler: ": #GHC HEAD"
+    addons: {apt: {packages: [cabal-install-head,ghc-head,happy-1.19.5,alex-3.1.7], sources: [hvr-ghc]}}
 
-  - env: BUILD=stack ARGS="--resolver lts-8"
-    compiler: ": #stack 8.0.2 (lts-8)"
-    addons: {apt: {packages: [ghc-8.0.2,libgmp-dev], sources: [hvr-ghc]}}
+  # Build using the configuration specified in the stack.yaml file in the
+  # current directory.
+  - env: BUILD=stack ARGS=""
+    compiler: ": #stack default"
+    addons: {apt: {packages: [libgmp-dev]}}
 
-  - env: BUILD=stack ARGS="--resolver lts-9"
-    compiler: ": #stack 8.0.2 (lts-9)"
-    addons: {apt: {packages: [ghc-8.0.2,libgmp-dev], sources: [hvr-ghc]}}
+  # The Stack LTS builds.
+  # (There are currently none because as of 2018-02-27,
+  # servant-checked-exceptions depends on servant >= 0.12, but the latest lts
+  # release only uses servant-0.11).
 
   # Nightly builds are allowed to fail
   - env: BUILD=stack ARGS="--resolver nightly"
     compiler: ": #stack nightly"
     addons: {apt: {packages: [libgmp-dev]}}
 
-  # Build on OS X in addition to Linux
-  # - env: BUILD=stack ARGS="--resolver lts-6"
-  #   compiler: ": #stack 7.10.3 (lts-6) osx"
-  #   os: osx
-
-  # - env: BUILD=stack ARGS="--resolver lts-7"
-  #   compiler: ": #stack 8.0.1 (lts-7) osx"
-  #   os: osx
-
-  - env: BUILD=stack ARGS="--resolver lts-8"
-    compiler: ": #stack 8.0.2 (lts-8) osx"
-    os: osx
-
-  - env: BUILD=stack ARGS="--resolver lts-9"
-    compiler: ": #stack 8.0.2 (lts-9) osx"
-    os: osx
+  # Build on OS X with Stack in addition to Linux.
+  # (There are currently no builds for the same reason as above.)
 
   - env: BUILD=stack ARGS="--resolver nightly"
+    env: BUILD=cabal GHCVER=head  CABALVER=head HAPPYVER=1.19.5 ALEXVER=3.1.7
     compiler: ": #stack nightly osx"
     os: osx
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,12 +63,12 @@ matrix:
   # (There are currently no builds for the same reason as above.)
 
   - env: BUILD=stack ARGS="--resolver nightly"
-    env: BUILD=cabal GHCVER=head  CABALVER=head HAPPYVER=1.19.5 ALEXVER=3.1.7
     compiler: ": #stack nightly osx"
     os: osx
 
   allow_failures:
   - env: BUILD=stack ARGS="--resolver nightly"
+  - env: BUILD=cabal GHCVER=head  CABALVER=head HAPPYVER=1.19.5 ALEXVER=3.1.7
   - os: osx
 
 before_install:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 
+## 1.1.0.0
+
+*   Updated the servant dependency to >= 0.12.
+
 ## 1.0.0.0
 
 *   Add a `ErrStatus` class that can be used to set the HTTP Status Code. Given

--- a/servant-checked-exceptions.cabal
+++ b/servant-checked-exceptions.cabal
@@ -1,5 +1,5 @@
 name:                servant-checked-exceptions
-version:             1.0.0.0
+version:             1.1.0.0
 synopsis:            Checked exceptions for Servant APIs.
 description:         Please see <https://github.com/cdepillabout/servant-checked-exceptions#readme README.md>.
 homepage:            https://github.com/cdepillabout/servant-checked-exceptions
@@ -41,11 +41,11 @@ library
                      , http-types
                      , profunctors
                      , tagged
-                     , servant >= 0.12 && < 0.14
-                     , servant-client >= 0.12 && < 0.14
-                     , servant-client-core >= 0.12 && < 0.14
-                     , servant-docs >= 0.10 && < 0.14
-                     , servant-server >= 0.12 && < 0.14
+                     , servant >= 0.12
+                     , servant-client >= 0.12
+                     , servant-client-core >= 0.12
+                     , servant-docs >= 0.10
+                     , servant-server >= 0.12
                      , text
                      , wai
   default-language:    Haskell2010

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,7 +1,7 @@
 # For more information, see: http://docs.haskellstack.org/en/stable/yaml_configuration.html
 
 # Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
-resolver: lts-10.5
+resolver: nightly-2018-02-26
 
 # Local packages, usually specified by relative directory name
 packages:


### PR DESCRIPTION
This bumps the version of servant-checked-exceptions to 1.1.0.0.

The changes in this PR are so that #22 is releasable to Hackage.