### PR TITLE
Add EnvelopeT

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,9 +60,9 @@ matrix:
   # - env: BUILD=cabal GHCVER=8.0.2 CABALVER=1.24 HAPPYVER=1.19.5 ALEXVER=3.1.7
   #   compiler: ": #GHC 8.0.2"
   #   addons: {apt: {packages: [cabal-install-1.24,ghc-8.0.2,happy-1.19.5,alex-3.1.7], sources: [hvr-ghc]}}
-  - env: BUILD=cabal GHCVER=8.2.2 CABALVER=2.0 HAPPYVER=1.19.5 ALEXVER=3.1.7
-    compiler: ": #GHC 8.2.2"
-    addons: {apt: {packages: [cabal-install-2.0,ghc-8.2.2,happy-1.19.5,alex-3.1.7], sources: [hvr-ghc]}}
+  # - env: BUILD=cabal GHCVER=8.2.2 CABALVER=2.0 HAPPYVER=1.19.5 ALEXVER=3.1.7
+  #   compiler: ": #GHC 8.2.2"
+  #   addons: {apt: {packages: [cabal-install-2.0,ghc-8.2.2,happy-1.19.5,alex-3.1.7], sources: [hvr-ghc]}}
   - env: BUILD=cabal GHCVER=8.4.4 CABALVER=2.2 HAPPYVER=1.19.5 ALEXVER=3.1.7
     compiler: ": #GHC 8.4.4"
     addons: {apt: {packages: [cabal-install-2.2,ghc-8.4.4,happy-1.19.5,alex-3.1.7], sources: [hvr-ghc]}}

--- a/servant-checked-exceptions-core/CHANGELOG.md
+++ b/servant-checked-exceptions-core/CHANGELOG.md
@@ -1,3 +1,17 @@
+## 2.2.0.0
+
+*   Add the `EnvelopeT` monad transformer. [#32]
+
+*   Add a few combinators for `Envelope`:
+
+        - `envelopeRemove`
+        - `envelopeHandle`
+        - `relaxEnvelope`
+        - `liftA2Envelope`
+        - `bindEnvelope`
+
+    [#32]
+
 ## 2.1.0.0
 
 *   Add support for servant-0.16 and remove support for all previous version of

--- a/servant-checked-exceptions-core/servant-checked-exceptions-core.cabal
+++ b/servant-checked-exceptions-core/servant-checked-exceptions-core.cabal
@@ -1,5 +1,5 @@
 name:                servant-checked-exceptions-core
-version:             2.1.0.0
+version:             2.2.0.0
 synopsis:            Checked exceptions for Servant APIs.
 description:         Please see <https://github.com/cdepillabout/servant-checked-exceptions#readme README.md>.
 homepage:            https://github.com/cdepillabout/servant-checked-exceptions

--- a/servant-checked-exceptions-core/servant-checked-exceptions-core.cabal
+++ b/servant-checked-exceptions-core/servant-checked-exceptions-core.cabal
@@ -35,6 +35,7 @@ library
   build-depends:       base >= 4.9 && < 5
                      , aeson
                      , bytestring
+                     , contravariant >= 1.5 -- needed for the Data.Functor.Contravariant module in GHC < 8.6
                      , http-media
                      , http-types
                      , mtl

--- a/servant-checked-exceptions-core/servant-checked-exceptions-core.cabal
+++ b/servant-checked-exceptions-core/servant-checked-exceptions-core.cabal
@@ -44,7 +44,7 @@ library
                      , servant >= 0.12
                      , servant-docs >= 0.10
                      , text
-                     , world-peace
+                     , world-peace >= 1.0.0.0
   default-language:    Haskell2010
   ghc-options:         -Wall -fwarn-incomplete-uni-patterns -fwarn-incomplete-record-updates -fwarn-monomorphism-restriction
   other-extensions:    QuasiQuotes

--- a/servant-checked-exceptions-core/servant-checked-exceptions-core.cabal
+++ b/servant-checked-exceptions-core/servant-checked-exceptions-core.cabal
@@ -35,7 +35,8 @@ library
   build-depends:       base >= 4.9 && < 5
                      , aeson
                      , bytestring
-                     , contravariant >= 1.5 -- needed for the Data.Functor.Contravariant module in GHC < 8.6
+                       -- contravariant is needed for the Data.Functor.Contravariant module in GHC < 8.6
+                     , contravariant >= 1.5
                      , http-media
                      , http-types
                      , mtl

--- a/servant-checked-exceptions-core/servant-checked-exceptions-core.cabal
+++ b/servant-checked-exceptions-core/servant-checked-exceptions-core.cabal
@@ -25,6 +25,7 @@ library
                      , Servant.Checked.Exceptions.Verbs
                      , Servant.Checked.Exceptions.Internal
                      , Servant.Checked.Exceptions.Internal.Envelope
+                     , Servant.Checked.Exceptions.Internal.EnvelopeT
                      , Servant.Checked.Exceptions.Internal.Prism
                      , Servant.Checked.Exceptions.Internal.Servant
                      , Servant.Checked.Exceptions.Internal.Servant.API
@@ -36,8 +37,10 @@ library
                      , bytestring
                      , http-media
                      , http-types
+                     , mtl
                      , profunctors
                      , tagged
+                     , transformers
                      , servant >= 0.12
                      , servant-docs >= 0.10
                      , text

--- a/servant-checked-exceptions-core/src/Servant/Checked/Exceptions.hs
+++ b/servant-checked-exceptions-core/src/Servant/Checked/Exceptions.hs
@@ -152,6 +152,12 @@ module Servant.Checked.Exceptions
   , fromEnvelopeOrM
   , errEnvelopeMatch
   , catchesEnvelope
+  , envelopeRemove
+  , envelopeHandle
+  -- ** Other 'Envelope' combinators
+  , relaxEnvelope
+  , liftA2Envelope
+  , bindEnvelope
   -- *** 'Envelope' optics
   , _SuccEnvelope
   , _ErrEnvelope
@@ -166,6 +172,17 @@ module Servant.Checked.Exceptions
   -- *** 'EnvelopeT' constructors
   , pureSuccEnvT
   , throwErrEnvT
+  -- ** 'EnvelopeT' destructors
+  , envelopeT
+  , fromEnvT
+  , fromEnvTOr
+  , errEnvTMatch
+  , catchesEnvT
+  , emptyEnvT
+  , relaxEnvT
+  , combineEnvT
+  , envTRemove
+  , envTHandle
   -- ** 'Envelope' and 'ExceptT'
   , envTToExceptT
   , exceptTToEnvT

--- a/servant-checked-exceptions-core/src/Servant/Checked/Exceptions.hs
+++ b/servant-checked-exceptions-core/src/Servant/Checked/Exceptions.hs
@@ -179,10 +179,12 @@ module Servant.Checked.Exceptions
   , errEnvTMatch
   , catchesEnvT
   , emptyEnvT
-  , relaxEnvT
-  , combineEnvT
   , envTRemove
   , envTHandle
+  -- ** Other 'EnvelopeT' combinators
+  , relaxEnvT
+  , liftA2EnvT
+  , bindEnvT
   -- ** 'Envelope' and 'ExceptT'
   , envTToExceptT
   , exceptTToEnvT

--- a/servant-checked-exceptions-core/src/Servant/Checked/Exceptions.hs
+++ b/servant-checked-exceptions-core/src/Servant/Checked/Exceptions.hs
@@ -160,18 +160,23 @@ module Servant.Checked.Exceptions
   , envelopeToEither
   , eitherToEnvelope
   , isoEnvelopeEither
+  -- * 'EnvelopeT' short-circuiting monad transformer
+  , EnvelopeT(..)
+  -- ** 'EnvelopeT' helper functions
+  -- *** 'EnvelopeT' constructors
+  , pureSuccEnvT
+  , throwErrEnvT
+  -- ** 'Envelope' and 'ExceptT'
+  , envTToExceptT
+  , exceptTToEnvT
   -- * Re-exported modules
   -- | "Data.WorldPeace" exports the 'OpenUnion' type as well as other
   -- combinators.  It also exports the 'OpenProduct' type and 'ToProduct' type
   -- class used by some of the functions above.
   , module Data.WorldPeace
-  , module Servant.Checked.Exceptions.Internal.Servant.Docs
   ) where
 
 import Data.WorldPeace
 import Network.HTTP.Types (Status)
 
-import Servant.Checked.Exceptions.Internal.Envelope
-import Servant.Checked.Exceptions.Internal.Servant.API
-import Servant.Checked.Exceptions.Internal.Servant.Docs
-import Servant.Checked.Exceptions.Internal.Verbs
+import Servant.Checked.Exceptions.Internal

--- a/servant-checked-exceptions-core/src/Servant/Checked/Exceptions.hs
+++ b/servant-checked-exceptions-core/src/Servant/Checked/Exceptions.hs
@@ -86,6 +86,14 @@ and
 <https://github.com/cdepillabout/servant-checked-exceptions/blob/master/example/Docs.hs documentation>.
 The <https://github.com/cdepillabout/servant-checked-exceptions README.md>
 shows how to compile and run the examples.
+
+There is also an 'EnvelopeT' monad transformer.  'Envelope' and 'EnvelopeT'
+have a similar relationship to 'Either' and 'ExceptT'.
+
+The following is an example of how 'EnvelopeT' can be used:
+
+<https://github.com/cdepillabout/servant-checked-exceptions/blob/master/example/EnvelopeT.hs EnvelopeT example>
+
 -}
 
 module Servant.Checked.Exceptions

--- a/servant-checked-exceptions-core/src/Servant/Checked/Exceptions.hs
+++ b/servant-checked-exceptions-core/src/Servant/Checked/Exceptions.hs
@@ -180,7 +180,6 @@ module Servant.Checked.Exceptions
   , catchesEnvT
   , emptyEnvT
   , envTRemove
-  , envTHandle
   -- ** Other 'EnvelopeT' combinators
   , relaxEnvT
   , liftA2EnvT

--- a/servant-checked-exceptions-core/src/Servant/Checked/Exceptions/Envelope.hs
+++ b/servant-checked-exceptions-core/src/Servant/Checked/Exceptions/Envelope.hs
@@ -16,6 +16,12 @@ module Servant.Checked.Exceptions.Envelope (
   , fromEnvelopeOrM
   , errEnvelopeMatch
   , catchesEnvelope
+  , envelopeRemove
+  , envelopeHandle
+  -- ** Other Envelope combinators
+  , relaxEnvelope
+  , liftA2Envelope
+  , bindEnvelope
   -- ** Optics
   , _SuccEnvelope
   , _ErrEnvelope
@@ -29,6 +35,17 @@ module Servant.Checked.Exceptions.Envelope (
   -- ** EnvelopeT constructors
   , pureSuccEnvT
   , throwErrEnvT
+  -- ** EnvelopeT destructors
+  , envelopeT
+  , fromEnvT
+  , fromEnvTOr
+  , errEnvTMatch
+  , catchesEnvT
+  , emptyEnvT
+  , relaxEnvT
+  , combineEnvT
+  , envTRemove
+  , envTHandle
   -- ** ExceptT
   , envTToExceptT
   , exceptTToEnvT

--- a/servant-checked-exceptions-core/src/Servant/Checked/Exceptions/Envelope.hs
+++ b/servant-checked-exceptions-core/src/Servant/Checked/Exceptions/Envelope.hs
@@ -42,10 +42,12 @@ module Servant.Checked.Exceptions.Envelope (
   , errEnvTMatch
   , catchesEnvT
   , emptyEnvT
-  , relaxEnvT
-  , combineEnvT
   , envTRemove
   , envTHandle
+  -- ** Other EnvelopeT combinators
+  , relaxEnvT
+  , liftA2EnvT
+  , bindEnvT
   -- ** ExceptT
   , envTToExceptT
   , exceptTToEnvT

--- a/servant-checked-exceptions-core/src/Servant/Checked/Exceptions/Envelope.hs
+++ b/servant-checked-exceptions-core/src/Servant/Checked/Exceptions/Envelope.hs
@@ -43,7 +43,6 @@ module Servant.Checked.Exceptions.Envelope (
   , catchesEnvT
   , emptyEnvT
   , envTRemove
-  , envTHandle
   -- ** Other EnvelopeT combinators
   , relaxEnvT
   , liftA2EnvT

--- a/servant-checked-exceptions-core/src/Servant/Checked/Exceptions/Envelope.hs
+++ b/servant-checked-exceptions-core/src/Servant/Checked/Exceptions/Envelope.hs
@@ -2,12 +2,12 @@ module Servant.Checked.Exceptions.Envelope (
   -- * Envelope
     Envelope(..)
   -- * Helper functions
-  -- ** Envelope Constructors
+  -- ** Envelope constructors
   , toSuccEnvelope
   , toErrEnvelope
   , pureSuccEnvelope
   , pureErrEnvelope
-  -- ** Envelope Destructors
+  -- ** Envelope destructors
   , envelope
   , emptyEnvelope
   , fromEnvelope
@@ -24,8 +24,16 @@ module Servant.Checked.Exceptions.Envelope (
   , envelopeToEither
   , eitherToEnvelope
   , isoEnvelopeEither
+  -- * EnvelopeT
+  , EnvelopeT(..)
+  -- ** EnvelopeT constructors
+  , pureSuccEnvT
+  , throwErrEnvT
+  -- ** ExceptT
+  , envTToExceptT
+  , exceptTToEnvT
   -- * Setup code for doctests
   -- $setup
   ) where
 
-import Servant.Checked.Exceptions.Internal.Envelope
+import Servant.Checked.Exceptions.Internal

--- a/servant-checked-exceptions-core/src/Servant/Checked/Exceptions/Internal.hs
+++ b/servant-checked-exceptions-core/src/Servant/Checked/Exceptions/Internal.hs
@@ -1,11 +1,13 @@
 module Servant.Checked.Exceptions.Internal
   ( module Servant.Checked.Exceptions.Internal.Envelope
+  , module Servant.Checked.Exceptions.Internal.EnvelopeT
   , module Servant.Checked.Exceptions.Internal.Verbs
   , module Servant.Checked.Exceptions.Internal.Servant
   , module Servant.Checked.Exceptions.Internal.Util
   ) where
 
 import Servant.Checked.Exceptions.Internal.Envelope
+import Servant.Checked.Exceptions.Internal.EnvelopeT
 import Servant.Checked.Exceptions.Internal.Verbs
 import Servant.Checked.Exceptions.Internal.Servant
 import Servant.Checked.Exceptions.Internal.Util

--- a/servant-checked-exceptions-core/src/Servant/Checked/Exceptions/Internal/Envelope.hs
+++ b/servant-checked-exceptions-core/src/Servant/Checked/Exceptions/Internal/Envelope.hs
@@ -54,14 +54,18 @@ import Data.Semigroup (Semigroup((<>), stimes), stimesIdempotent)
 import Data.Typeable (Typeable)
 import Data.WorldPeace
   ( Contains
+  , ElemRemove
   , IsMember
   , OpenUnion
+  , Remove
   , ReturnX
   , ToOpenProduct
   , absurdUnion
   , catchesOpenUnion
+  , openUnionHandle
   , openUnionLift
   , openUnionPrism
+  , openUnionRemove
   , relaxOpenUnion
   )
 import GHC.Generics (Generic)
@@ -198,10 +202,16 @@ toSuccEnvelope :: a -> Envelope es a
 toSuccEnvelope = pure
 
 -- | 'pureErrEnvelope' is 'toErrEnvelope' lifted up to an 'Applicative'.
+--
+-- >>> pureErrEnvelope 'c' :: Maybe (Envelope '[Char] Int)
+-- Just (ErrEnvelope (Identity 'c'))
 pureErrEnvelope :: (Applicative m, IsMember e es) => e -> m (Envelope es a)
 pureErrEnvelope = pure . toErrEnvelope
 
 -- | 'pureSuccEnvelope' is 'toSuccEnvelope' lifted up to an 'Applicative'.
+--
+-- >>> pureSuccEnvelope 3 :: Maybe (Envelope '[Char] Int)
+-- Just (SuccEnvelope 3)
 pureSuccEnvelope :: Applicative m => a -> m (Envelope es a)
 pureSuccEnvelope = pure . toSuccEnvelope
 
@@ -225,34 +235,27 @@ envelope :: (OpenUnion es -> c) -> (a -> c) -> Envelope es a -> c
 envelope f _ (ErrEnvelope es) = f es
 envelope _ f (SuccEnvelope a) = f a
 
--- | Change the errors type in an 'Envelope' to a larger set.
+-- | Similar to 'liftA2', but more general.  This allows you to operate on two
+-- 'Envelope's with different sets of errors.  The resulting 'Envelope' is a
+-- combination of the errors in each of the input 'Envelope's.
 --
--- >>> let double = 3.5 :: Double
--- >>> let env = toErrEnvelope double :: Envelope '[Double, Int] Char
--- >>> relaxEnvelope env :: Envelope '[(), Double, String, Int] Char
--- ErrEnvelope (Identity 3.5)
-relaxEnvelope :: Contains es1 es2 => Envelope es1 a -> Envelope es2 a
-relaxEnvelope (SuccEnvelope a) = SuccEnvelope a
-relaxEnvelope (ErrEnvelope es) = ErrEnvelope (relaxOpenUnion es)
-
--- | Combine two 'Envelope's.  Generalize the set of errors to include the errors
--- from both 'Envelope's.
+-- ==== __Examples__
 --
 -- >>> let env1 = toSuccEnvelope "hello" :: Envelope '[Double, Int] String
 -- >>> let env2 = toSuccEnvelope " world" :: Envelope '[Char] String
--- >>> combineEnvelopes (<>) env1 env2 :: Envelope '[Double, Int, Char] String
+-- >>> liftA2Envelope (<>) env1 env2 :: Envelope '[Double, Int, Char] String
 -- SuccEnvelope "hello world"
 --
 -- If either of the 'Envelope's is an 'ErrEnvelope', then return the 'ErrEnvelope'.
 --
 -- >>> let env3 = toErrEnvelope "some err" :: Envelope '[String, Double] Int
 -- >>> let env4 = toSuccEnvelope 1 :: Envelope '[Char] Int
--- >>> combineEnvelopes (+) env3 env4 :: Envelope '[String, Double, Char] Int
+-- >>> liftA2Envelope (+) env3 env4 :: Envelope '[String, Double, Char] Int
 -- ErrEnvelope (Identity "some err")
 --
 -- >>> let env5 = toSuccEnvelope "hello" :: Envelope '[Char] String
 -- >>> let env6 = toErrEnvelope 3.5 :: Envelope '[(), Double] String
--- >>> combineEnvelopes (<>) env5 env6 :: Envelope '[Char, (), Double] String
+-- >>> liftA2Envelope (<>) env5 env6 :: Envelope '[Char, (), Double] String
 -- ErrEnvelope (Identity 3.5)
 --
 -- If both of the 'Envelope's is an 'ErrEnvelope', then short-circuit and only
@@ -260,12 +263,53 @@ relaxEnvelope (ErrEnvelope es) = ErrEnvelope (relaxOpenUnion es)
 --
 -- >>> let env7 = toErrEnvelope 3.5 :: Envelope '[(), Double] String
 -- >>> let env8 = toErrEnvelope 'x' :: Envelope '[Int, Char] String
--- >>> combineEnvelopes (<>) env7 env8 :: Envelope '[(), Double, Int, Char] String
+-- >>> liftA2Envelope (<>) env7 env8 :: Envelope '[(), Double, Int, Char] String
 -- ErrEnvelope (Identity 3.5)
-combineEnvelopes :: (Contains es1 fullEs, Contains es2 fullEs) => (a -> b -> c) -> Envelope es1 a -> Envelope es2 b -> Envelope fullEs c
-combineEnvelopes f (SuccEnvelope a) (SuccEnvelope b) = SuccEnvelope (f a b)
-combineEnvelopes _ (ErrEnvelope es) _ = ErrEnvelope (relaxOpenUnion es)
-combineEnvelopes _ _ (ErrEnvelope es) = ErrEnvelope (relaxOpenUnion es)
+liftA2Envelope :: (Contains es1 fullEs, Contains es2 fullEs) => (a -> b -> c) -> Envelope es1 a -> Envelope es2 b -> Envelope fullEs c
+liftA2Envelope f (SuccEnvelope a) (SuccEnvelope b) = SuccEnvelope (f a b)
+liftA2Envelope _ (ErrEnvelope es) _ = ErrEnvelope (relaxOpenUnion es)
+liftA2Envelope _ _ (ErrEnvelope es) = ErrEnvelope (relaxOpenUnion es)
+
+-- | This is like 'liftA2Envelope' but for monadic bind ('>>=').
+--
+-- This allows you to bind on 'Envelope's that contain different errors.
+--
+-- The resulting 'Envelope' must have a superset of the errors in two input
+-- 'Envelope's.
+--
+-- ==== __Examples__
+--
+-- >>> let env1 = toSuccEnvelope "hello" :: Envelope '[Double, Int] String
+-- >>> let f1 str = toSuccEnvelope (length str) :: Envelope '[Char] Int
+-- >>> bindEnvelope env1 f1 :: Envelope '[Double, Int, Char] Int
+-- SuccEnvelope 5
+--
+-- If either of the 'Envelope's is an 'ErrEnvelope', then return the 'ErrEnvelope'.
+--
+-- >>> let env2 = toErrEnvelope "some err" :: Envelope '[String, Double] Int
+-- >>> let f2 i = toSuccEnvelope (i + 1) :: Envelope '[Char] Int
+-- >>> bindEnvelope env2 f2 :: Envelope '[String, Double, Char] Int
+-- ErrEnvelope (Identity "some err")
+--
+-- >>> let env3 = toSuccEnvelope "hello" :: Envelope '[Char] String
+-- >>> let f3 _ = toErrEnvelope 3.5 :: Envelope '[(), Double] Int
+-- >>> bindEnvelope env3 f3 :: Envelope '[Char, (), Double] Int
+-- ErrEnvelope (Identity 3.5)
+--
+-- If both of the 'Envelope's is an 'ErrEnvelope', then short-circuit and only
+-- return the first 'ErrEnvelope'.
+--
+-- >>> let env4 = toErrEnvelope 3.5 :: Envelope '[(), Double] String
+-- >>> let f4 _ = toErrEnvelope 'x' :: Envelope '[Int, Char] String
+-- >>> bindEnvelope env4 f4 :: Envelope '[Char, (), Double, Int] String
+-- ErrEnvelope (Identity 3.5)
+bindEnvelope
+  :: (Contains es1 fullEs, Contains es2 fullEs)
+  => Envelope es1 a
+  -> (a -> Envelope es2 b)
+  -> Envelope fullEs b
+bindEnvelope (SuccEnvelope a) f = relaxEnvelope $ f a
+bindEnvelope (ErrEnvelope u) _ = relaxEnvelope (ErrEnvelope u)
 
 -- | Unwrap an 'Envelope' that cannot contain an error.
 --
@@ -525,3 +569,109 @@ catchesEnvelope
   => tuple -> (a -> x) -> Envelope es a -> x
 catchesEnvelope _ a2x (SuccEnvelope a) = a2x a
 catchesEnvelope tuple _ (ErrEnvelope u) = catchesOpenUnion tuple u
+
+-- | Change the errors type in an 'Envelope' to a larger set.
+--
+-- >>> let double = 3.5 :: Double
+-- >>> let env = toErrEnvelope double :: Envelope '[Double, Int] Char
+-- >>> relaxEnvelope env :: Envelope '[(), Int, Double, String] Char
+-- ErrEnvelope (Identity 3.5)
+relaxEnvelope :: Contains es biggerEs => Envelope es a -> Envelope biggerEs a
+relaxEnvelope (SuccEnvelope a) = SuccEnvelope a
+relaxEnvelope (ErrEnvelope u) = ErrEnvelope (relaxOpenUnion u)
+
+-- | This function allows you to try to remove individual error types from an
+-- 'Envelope'.
+--
+-- This can be used to handle only certain error types in an 'Envelope',
+-- instead of having to handle all of them at the same time.  This can be more
+-- convenient than a function like 'catchesEnvelope'.
+--
+-- ==== __Examples__
+--
+-- Pulling out an error in an 'Envelope':
+--
+-- >>> let env1 = toErrEnvelope "hello" :: Envelope '[String, Double] Float
+-- >>> envelopeRemove env1 :: Either (Envelope '[Double] Float) String
+-- Right "hello"
+--
+-- Failing to pull out an error in an 'Envelope':
+--
+-- >>> let env2 = toErrEnvelope (3.5 :: Double) :: Envelope '[String, Double] Float
+-- >>> envelopeRemove env2 :: Either (Envelope '[Double] Float) String
+-- Left (ErrEnvelope (Identity 3.5))
+--
+-- Note that if you have an 'Envelope' with multiple errors of the same type,
+-- they will all be handled at the same time:
+--
+-- >>> let env3 = toErrEnvelope (3.5 :: Double) :: Envelope '[String, Double, Char, Double] Float
+-- >>> envelopeRemove env3 :: Either (Envelope '[String, Char] Float) Double
+-- Right 3.5
+--
+-- 'SuccEnvelope' gets passed through as expected:
+--
+-- >>> let env4 = toSuccEnvelope 3.5 :: Envelope '[String, Double] Float
+-- >>> envelopeRemove env4 :: Either (Envelope '[Double] Float) String
+-- Left (SuccEnvelope 3.5)
+envelopeRemove
+  :: forall e es a
+   . ElemRemove e es
+  => Envelope es a
+  -> Either (Envelope (Remove e es) a) e
+envelopeRemove (SuccEnvelope a) = Left (SuccEnvelope a)
+envelopeRemove (ErrEnvelope u) =
+  case openUnionRemove u of
+    Left u2 -> Left (ErrEnvelope u2)
+    Right e -> Right e
+
+-- | Handle a single case in an 'Envelope'.  This is similar to 'envelope'
+-- but lets you handle any case within the 'Envelope', not just the first one.
+--
+-- ==== __Examples__
+--
+-- Handling the first item in an 'Envelope':
+--
+-- >>> let env1 = toErrEnvelope 3.5 :: Envelope '[Double, Int] Char
+-- >>> let printDouble = print :: Double -> IO ()
+-- >>> let printEnv = print :: Envelope '[Int] Char -> IO ()
+-- >>> envelopeHandle printEnv printDouble env1
+-- 3.5
+--
+-- Handling a middle item in an 'Envelope':
+--
+-- >>> let env2 = toErrEnvelope (3.5 :: Double) :: Envelope '[Char, Double, Int] Float
+-- >>> let printEnv = print :: Envelope '[Char, Int] Float -> IO ()
+-- >>> envelopeHandle printEnv printDouble env2
+-- 3.5
+--
+-- Failing to handle an item in an 'Envelope'.  In the following example, the
+-- @printEnv@ function is called:
+--
+-- >>> let env3 = toErrEnvelope 'c' :: Envelope '[Char, Double, Int] Float
+-- >>> let printEnv = print :: Envelope '[Char, Int] Float -> IO ()
+-- >>> envelopeHandle printEnv printDouble env3
+-- ErrEnvelope (Identity 'c')
+--
+-- If you have duplicates in your 'Envelope', they will both get handled with
+-- a single call to 'unionHandle'.
+--
+-- >>> let env4 = toErrEnvelope 3.5 :: Envelope '[Double, Double, Int] Char
+-- >>> let printEnv = print :: Envelope '[Int] Char -> IO ()
+-- >>> envelopeHandle printEnv printDouble env4
+-- 3.5
+--
+-- 'SuccEnvelope' gets passed through as expected:
+--
+-- >>> let env5 = toSuccEnvelope 3.5 :: Envelope '[String, Double] Float
+-- >>> let printEnv = print :: Envelope '[String] Float -> IO ()
+-- >>> envelopeHandle printEnv printDouble env5
+-- SuccEnvelope 3.5
+envelopeHandle
+  :: ElemRemove e es
+  => (Envelope (Remove e es) a -> x)
+  -> (e -> x)
+  -> Envelope es a
+  -> x
+envelopeHandle handler _ (SuccEnvelope a) = handler (SuccEnvelope a)
+envelopeHandle handler errHandler (ErrEnvelope u) =
+  openUnionHandle (handler . ErrEnvelope) errHandler u

--- a/servant-checked-exceptions-core/src/Servant/Checked/Exceptions/Internal/EnvelopeT.hs
+++ b/servant-checked-exceptions-core/src/Servant/Checked/Exceptions/Internal/EnvelopeT.hs
@@ -10,6 +10,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 {- |
@@ -34,29 +35,54 @@ module Servant.Checked.Exceptions.Internal.EnvelopeT where
 import Control.Monad.Except (ExceptT(ExceptT))
 import Control.Monad.IO.Class (MonadIO(liftIO))
 import Control.Monad.Trans.Class (MonadTrans(lift))
+import Data.Functor.Classes (Show1, liftShowList, liftShowsPrec, showsPrec1, showsUnaryWith)
 import Data.WorldPeace
-  ( IsMember
+  ( Contains
+  , IsMember
   , OpenUnion
-  , ReturnX
-  , ToOpenProduct
-  , absurdUnion
-  , catchesOpenUnion
-  , openUnionLift
-  , openUnionPrism
   )
 
 import Servant.Checked.Exceptions.Internal.Envelope
   ( Envelope(ErrEnvelope, SuccEnvelope)
+  , combineEnvelopes
   , eitherToEnvelope
   , emptyEnvelope
   , envelopeToEither
   , pureErrEnvelope
   , pureSuccEnvelope
+  , relaxEnvelope
   )
+
+-- $setup
+-- >>> :set -XDataKinds
+-- >>> :set -XTypeOperators
+-- >>> import Data.Functor.Identity (Identity(Identity))
 
 data EnvelopeT es m a = EnvelopeT
   { runEnvelopeT :: m (Envelope es a)
   } deriving Functor
+
+instance (Show (OpenUnion es), Show1 m) => Show1 (EnvelopeT es m) where
+  liftShowsPrec
+    :: forall a
+     . (Int -> a -> ShowS)
+    -> ([a] -> ShowS)
+    -> Int
+    -> EnvelopeT es m a -> ShowS
+  liftShowsPrec sp sl d (EnvelopeT m) =
+    showsUnaryWith showInnerM "EnvelopeT" d m
+    where
+      showInnerM :: Int -> m (Envelope es a) -> ShowS
+      showInnerM = liftShowsPrec sp' sl'
+
+      sp' :: Int -> Envelope es a -> ShowS
+      sp' = liftShowsPrec sp sl
+
+      sl' :: [Envelope es a] -> ShowS
+      sl' = liftShowList sp sl
+
+instance (Show (OpenUnion e), Show1 m, Show a) => Show (EnvelopeT e m a) where
+  showsPrec = showsPrec1
 
 instance Monad m => Applicative (EnvelopeT es m) where
   pure :: a -> EnvelopeT es m a
@@ -114,8 +140,56 @@ exceptTToEnvT (ExceptT m) = EnvelopeT $ fmap eitherToEnvelope m
 
 -- | Safely unwrap an 'EnvelopeT'.
 --
--- >>> let myenvT = pure "hello" :: EnvelopeT '[] Identity String
--- >>> emptyEnvT myenvT :: Identity String
--- Identity "hello"
+-- >>> let myenvT = pure "hello" :: EnvelopeT '[] IO String
+-- >>> emptyEnvT myenvT :: IO String
+-- "hello"
 emptyEnvT :: Functor m => EnvelopeT '[] m a -> m a
 emptyEnvT (EnvelopeT m) = fmap emptyEnvelope m
+
+-- | Change the errors type in an 'EnvelopeT' to a larger set.
+--
+-- >>> let double = 3.5 :: Double
+-- >>> let envT1 = throwErrEnvT double :: EnvelopeT '[Int, Double] Identity Float
+-- >>> relaxEnvT envT1 :: EnvelopeT '[Char, Int, String, Double] Identity Float
+-- EnvelopeT (Identity (ErrEnvelope (Identity 3.5)))
+--
+-- >>> let envT2 = pure double :: EnvelopeT '[Char, Int] Identity Double
+-- >>> relaxEnvT envT2 :: EnvelopeT '[(), Char, String, Int] Identity Double
+-- EnvelopeT (Identity (SuccEnvelope 3.5))
+relaxEnvT :: (Functor m, Contains es1 es2) => EnvelopeT es1 m a -> EnvelopeT es2 m a
+relaxEnvT (EnvelopeT m) = EnvelopeT $ fmap relaxEnvelope m
+
+-- | Combine two 'EnvelopeT's.  Generalize the set of errors to include the errors
+-- from both 'EnvelopeT's.
+--
+-- >>> let env1 = pure "hello" :: EnvelopeT '[Double, Int] Identity String
+-- >>> let env2 = pure " world" :: EnvelopeT '[Char]  Identity String
+-- >>> combineEnvT (<>) env1 env2 :: EnvelopeT '[Double, Int, Char] Identity String
+-- EnvelopeT (Identity (SuccEnvelope "hello world"))
+--
+-- If either of the 'Envelope's is an 'ErrEnvelope', then return the 'ErrEnvelope'.
+--
+-- >>> let env3 = throwErrEnvT "some err" :: EnvelopeT '[String, Double] Identity Int
+-- >>> let env4 = pure 1 :: EnvelopeT '[Char]  Identity Int
+-- >>> combineEnvT (+) env3 env4 :: EnvelopeT '[String, Double, Char] Identity Int
+-- EnvelopeT (Identity (ErrEnvelope (Identity "some err")))
+--
+-- >>> let env5 = pure "hello" :: EnvelopeT '[Char] Identity String
+-- >>> let env6 = throwErrEnvT 3.5 :: EnvelopeT '[(), Double] Identity String
+-- >>> combineEnvT (<>) env5 env6 :: EnvelopeT '[Char, (), Double] Identity String
+-- EnvelopeT (Identity (ErrEnvelope (Identity 3.5)))
+--
+-- If both of the 'EnvelopeT's is an 'ErrEnvelope', then short-circuit and only
+-- return the first 'ErrEnvelope'.
+--
+-- >>> let env7 = throwErrEnvT 4.5 :: EnvelopeT '[(), Double] Identity String
+-- >>> let env8 = throwErrEnvT 'x' :: EnvelopeT '[Int, Char] Identity String
+-- >>> combineEnvT (<>) env7 env8 :: EnvelopeT '[(), Double, Int, Char] Identity String
+-- EnvelopeT (Identity (ErrEnvelope (Identity 4.5)))
+combineEnvT
+  :: (Contains es1 fullEs, Contains es2 fullEs, Applicative m)
+  => (a -> b -> c)
+  -> EnvelopeT es1 m a
+  -> EnvelopeT es2 m b
+  -> EnvelopeT fullEs m c
+combineEnvT f (EnvelopeT m) (EnvelopeT n) = EnvelopeT $ combineEnvelopes f <$> m <*> n

--- a/servant-checked-exceptions-core/src/Servant/Checked/Exceptions/Internal/EnvelopeT.hs
+++ b/servant-checked-exceptions-core/src/Servant/Checked/Exceptions/Internal/EnvelopeT.hs
@@ -476,13 +476,13 @@ bindEnvT (EnvelopeT m) f =
 -- >>> envTRemove env1 :: EnvelopeT '[Double] Identity (Either Float String)
 -- EnvelopeT (Identity (SuccEnvelope (Right "hello")))
 --
--- Failing to pull out an error in an 'Envelope':
+-- Failing to pull out an error in an 'EnvelopeT':
 --
 -- >>> let env2 = throwErrEnvT (3.5 :: Double) :: EnvelopeT '[String, Double] Identity Float
 -- >>> envTRemove env2 :: EnvelopeT '[Double] Identity (Either Float String)
 -- EnvelopeT (Identity (ErrEnvelope (Identity 3.5)))
 --
--- Note that if you have an 'Envelope' with multiple errors of the same type,
+-- Note that if you have an 'EnvelopeT' with multiple errors of the same type,
 -- they will all be handled at the same time:
 --
 -- >>> let env3 = throwErrEnvT (3.5 :: Double) :: EnvelopeT '[String, Double, Char, Double] Identity Float
@@ -506,13 +506,3 @@ envTRemove (EnvelopeT m) = EnvelopeT $ fmap go m
     case envelopeRemove envel of
       Right e -> SuccEnvelope (Right e)
       Left envel -> fmap Left envel
-
-envTHandle
-  :: (ElemRemove e es, Monad m)
-  => (a -> EnvelopeT (Remove e es) m x)
-  -> (e -> EnvelopeT (Remove e es) m x)
-  -> EnvelopeT es m a
-  -> EnvelopeT (Remove e es) m x
-envTHandle aHandler eHandler envT = do
-  aOrE <- envTRemove envT
-  either aHandler eHandler aOrE

--- a/servant-checked-exceptions-core/src/Servant/Checked/Exceptions/Internal/EnvelopeT.hs
+++ b/servant-checked-exceptions-core/src/Servant/Checked/Exceptions/Internal/EnvelopeT.hs
@@ -1,0 +1,121 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE DeriveFoldable #-}
+{-# LANGUAGE DeriveFunctor #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DeriveTraversable #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE InstanceSigs #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+{- |
+Module      :  Servant.Checked.Exceptions.Internal.EnvelopeT
+
+Copyright   :  Dennis Gosnell 2019
+License     :  BSD3
+
+Maintainer  :  Dennis Gosnell (cdep.illabout@gmail.com)
+Stability   :  experimental
+Portability :  unknown
+
+This module defines the 'EnvelopeT' type and helper functions. 'EnvelopeT' is a
+short-circuiting monad transformer.
+
+'Envelope' is similar to 'Either' where multiple errors types are possible.
+'EnvelopeT' is similar to 'ExceptT' in a similar manner.
+-}
+
+module Servant.Checked.Exceptions.Internal.EnvelopeT where
+
+import Control.Monad.Except (ExceptT(ExceptT))
+import Control.Monad.IO.Class (MonadIO(liftIO))
+import Control.Monad.Trans.Class (MonadTrans(lift))
+import Data.WorldPeace
+  ( IsMember
+  , OpenUnion
+  , ReturnX
+  , ToOpenProduct
+  , absurdUnion
+  , catchesOpenUnion
+  , openUnionLift
+  , openUnionPrism
+  )
+
+import Servant.Checked.Exceptions.Internal.Envelope
+  ( Envelope(ErrEnvelope, SuccEnvelope)
+  , eitherToEnvelope
+  , emptyEnvelope
+  , envelopeToEither
+  , pureErrEnvelope
+  , pureSuccEnvelope
+  )
+
+data EnvelopeT es m a = EnvelopeT
+  { runEnvelopeT :: m (Envelope es a)
+  } deriving Functor
+
+instance Monad m => Applicative (EnvelopeT es m) where
+  pure :: a -> EnvelopeT es m a
+  pure a = EnvelopeT $ pureSuccEnvelope a
+
+  (<*>) :: EnvelopeT es m (a -> b) -> EnvelopeT es m a -> EnvelopeT es m b
+  EnvelopeT a2b <*> EnvelopeT a = EnvelopeT $ go <$> a2b <*> a
+    where
+      go :: Envelope es (a -> b) -> Envelope es a -> Envelope es b
+      go = (<*>)
+
+instance Monad m => Monad (EnvelopeT es m) where
+  (>>=) :: EnvelopeT es m a -> (a -> EnvelopeT es m b) -> EnvelopeT es m b
+  (EnvelopeT m) >>= k = EnvelopeT $ do
+    env <- m
+    case env of
+      SuccEnvelope a -> runEnvelopeT $ k a
+      ErrEnvelope err -> pure $ ErrEnvelope err
+
+instance MonadTrans (EnvelopeT es) where
+  lift :: Monad m => m a -> EnvelopeT es m a
+  lift m = EnvelopeT $ do
+    val <- m
+    pureSuccEnvelope val
+
+instance MonadIO m => MonadIO (EnvelopeT es m) where
+  liftIO :: IO a -> EnvelopeT es m a
+  liftIO = lift . liftIO
+
+-- | This is 'pure' for 'EnvelopeT'.
+--
+-- >>> pureSuccEnvT "hello" :: EnvelopeT '[] Identity String
+-- EnvelopeT (Identity (SuccEnvelope "hello"))
+pureSuccEnvT :: Applicative m => a -> EnvelopeT es m a
+pureSuccEnvT = EnvelopeT . pureSuccEnvelope
+
+-- | Throw an error in an 'ErrEnvelope'.
+--
+-- >>> let double = 3.5 :: Double
+-- >>> throwErrEnvT double :: EnvelopeT '[String, Double, Int] Identity ()
+-- EnvelopeT (Identity (ErrEnvelope (Identity 3.5)))
+--
+-- This is similar to 'throwError', but is specialized so you can throw just
+-- one of the error types.
+throwErrEnvT :: (Applicative m, IsMember e es) => e -> EnvelopeT es m a
+throwErrEnvT = EnvelopeT . pureErrEnvelope
+
+-- | Convert an 'EnvelopeT' to an 'ExceptT'.
+envTToExceptT :: Functor m => EnvelopeT es m a -> ExceptT (OpenUnion es) m a
+envTToExceptT (EnvelopeT m) = ExceptT $ fmap envelopeToEither m
+
+-- | Convert an 'ExceptT' to an 'EnvelopeT'.
+exceptTToEnvT :: Functor m => ExceptT (OpenUnion es) m a -> EnvelopeT es m a
+exceptTToEnvT (ExceptT m) = EnvelopeT $ fmap eitherToEnvelope m
+
+-- | Safely unwrap an 'EnvelopeT'.
+--
+-- >>> let myenvT = pure "hello" :: EnvelopeT '[] Identity String
+-- >>> emptyEnvT myenvT :: Identity String
+-- Identity "hello"
+emptyEnvT :: Functor m => EnvelopeT '[] m a -> m a
+emptyEnvT (EnvelopeT m) = fmap emptyEnvelope m

--- a/servant-checked-exceptions-core/src/Servant/Checked/Exceptions/Internal/EnvelopeT.hs
+++ b/servant-checked-exceptions-core/src/Servant/Checked/Exceptions/Internal/EnvelopeT.hs
@@ -461,7 +461,39 @@ bindEnvT (EnvelopeT m) f =
         let fullEs = relaxOpenUnion u
         in pure $ ErrEnvelope fullEs
 
--- TODO: Documentation
+-- | This function allows you to try to remove individual error types from an
+-- 'EnvelopeT'.
+--
+-- This can be used to handle only certain error types in an 'Envelope',
+-- instead of having to handle all of them at the same time.  This can be more
+-- convenient than a function like 'catchesEnvT'.
+--
+-- ==== __Examples__
+--
+-- Pulling out an error in an 'EnvelopeT':
+--
+-- >>> let env1 = throwErrEnvT "hello" :: EnvelopeT '[String, Double] Identity Float
+-- >>> envTRemove env1 :: EnvelopeT '[Double] Identity (Either Float String)
+-- EnvelopeT (Identity (SuccEnvelope (Right "hello")))
+--
+-- Failing to pull out an error in an 'Envelope':
+--
+-- >>> let env2 = throwErrEnvT (3.5 :: Double) :: EnvelopeT '[String, Double] Identity Float
+-- >>> envTRemove env2 :: EnvelopeT '[Double] Identity (Either Float String)
+-- EnvelopeT (Identity (ErrEnvelope (Identity 3.5)))
+--
+-- Note that if you have an 'Envelope' with multiple errors of the same type,
+-- they will all be handled at the same time:
+--
+-- >>> let env3 = throwErrEnvT (3.5 :: Double) :: EnvelopeT '[String, Double, Char, Double] Identity Float
+-- >>> envTRemove env3 :: EnvelopeT '[String, Char] Identity (Either Float Double)
+-- EnvelopeT (Identity (SuccEnvelope (Right 3.5)))
+--
+-- 'SuccEnvelope' gets passed through as expected:
+--
+-- >>> let env4 = pureSuccEnvT 3.5 :: EnvelopeT '[String, Double] Identity Float
+-- >>> envTRemove env4 :: EnvelopeT '[Double] Identity (Either Float String)
+-- EnvelopeT (Identity (SuccEnvelope (Left 3.5)))
 envTRemove
   :: forall e es m a
    . (ElemRemove e es, Functor m)

--- a/servant-checked-exceptions-core/src/Servant/Checked/Exceptions/Internal/Util.hs
+++ b/servant-checked-exceptions-core/src/Servant/Checked/Exceptions/Internal/Util.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 {- |
 Module      :  Servant.Checked.Exceptions.Internal.Util
@@ -38,3 +39,28 @@ type family Snoc (as :: [k]) (b :: k) where
 -- >>> :set -XTypeOperators
 -- >>> import Data.Type.Equality ((:~:)(Refl))
 
+-- type family Unique (xs :: [k]) :: [k] where
+--   Unique '[] = '[]
+--   Unique (a ': as) = UniqueHelper a as
+
+-- type family UniqueHelper (xs :: [k]) (ys :: [k]) :: [k] where
+--   UniqueHelper '[] '[] = '[]
+--   UniqueHelper '[] (a ': as) = UniqueHelper '[a] as
+--   UniqueHelper (a ': as) '[] = (a ': as)
+--   UniqueHelper as (b ': bs) = If (Elem b as) (UniqueHelper as bs) (UniqueHelper (Snoc as b) bs)
+
+-- type family Elem
+
+type family UniqueAppend (xs :: [k]) (ys :: [k]) :: [k] where
+  UniqueAppend '[] ys = ys
+  UniqueAppend xs '[] = xs
+  UniqueAppend xs (y ': ys) = If (Elem y xs) (UniqueAppend xs ys) (UniqueAppend (Snoc xs y) ys)
+
+type family Elem (x :: k) (xs :: [k]) :: Bool where
+  Elem _ '[] = 'False
+  Elem x (x ': xs) = 'True
+  Elem x (y ': xs) = Elem x xs
+
+type family If (b :: Bool) (thenCase :: k) (elseCase :: k) :: k where
+  If 'True thenCase _ = thenCase
+  If 'False _ elseCase = elseCase

--- a/servant-checked-exceptions-core/src/Servant/Checked/Exceptions/Internal/Util.hs
+++ b/servant-checked-exceptions-core/src/Servant/Checked/Exceptions/Internal/Util.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
-{-# LANGUAGE UndecidableInstances #-}
 
 {- |
 Module      :  Servant.Checked.Exceptions.Internal.Util
@@ -39,28 +38,3 @@ type family Snoc (as :: [k]) (b :: k) where
 -- >>> :set -XTypeOperators
 -- >>> import Data.Type.Equality ((:~:)(Refl))
 
--- type family Unique (xs :: [k]) :: [k] where
---   Unique '[] = '[]
---   Unique (a ': as) = UniqueHelper a as
-
--- type family UniqueHelper (xs :: [k]) (ys :: [k]) :: [k] where
---   UniqueHelper '[] '[] = '[]
---   UniqueHelper '[] (a ': as) = UniqueHelper '[a] as
---   UniqueHelper (a ': as) '[] = (a ': as)
---   UniqueHelper as (b ': bs) = If (Elem b as) (UniqueHelper as bs) (UniqueHelper (Snoc as b) bs)
-
--- type family Elem
-
-type family UniqueAppend (xs :: [k]) (ys :: [k]) :: [k] where
-  UniqueAppend '[] ys = ys
-  UniqueAppend xs '[] = xs
-  UniqueAppend xs (y ': ys) = If (Elem y xs) (UniqueAppend xs ys) (UniqueAppend (Snoc xs y) ys)
-
-type family Elem (x :: k) (xs :: [k]) :: Bool where
-  Elem _ '[] = 'False
-  Elem x (x ': xs) = 'True
-  Elem x (y ': xs) = Elem x xs
-
-type family If (b :: Bool) (thenCase :: k) (elseCase :: k) :: k where
-  If 'True thenCase _ = thenCase
-  If 'False _ elseCase = elseCase

--- a/servant-checked-exceptions/CHANGELOG.md
+++ b/servant-checked-exceptions/CHANGELOG.md
@@ -1,3 +1,20 @@
+## 2.2.0.0
+
+*   Add the `EnvelopeT` monad transformer. [#32]
+
+*   Add a few combinators for `Envelope`:
+
+        - `envelopeRemove`
+        - `envelopeHandle`
+        - `relaxEnvelope`
+        - `liftA2Envelope`
+        - `bindEnvelope`
+
+    [#32]
+
+*   Add an example of using `EnvelopeT` in
+    `servant-checked-exceptions/example/EnvelopeT.hs`. [#32]
+
 ## 2.1.0.0
 
 *   Add support for servant-0.16 and remove support for all previous version of

--- a/servant-checked-exceptions/example/EnvelopeT.hs
+++ b/servant-checked-exceptions/example/EnvelopeT.hs
@@ -1,0 +1,133 @@
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE EmptyCase #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE InstanceSigs #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+-- | This example is very similar to @./Server.hs@, but it is making use of
+-- 'EnvelopeT' instead of just 'Envelope'.
+
+module Main where
+
+import Control.Monad.IO.Class (MonadIO(liftIO))
+import Data.Char (toLower)
+import Data.Proxy (Proxy(Proxy))
+import Network.Wai (Application)
+import Network.Wai.Handler.Warp (run)
+import Servant (Handler, (:<|>)((:<|>)), ServerT, serve)
+
+import Servant.Checked.Exceptions
+  ( Envelope
+  , EnvelopeT
+  , IsMember
+  , pureErrEnvelope
+  , pureSuccEnvelope
+  , relaxEnvT
+  , runEnvelopeT
+  , throwErrEnvT
+  )
+
+import Api
+  ( Api
+  , BadSearchTermErr(BadSearchTermErr)
+  , IncorrectCapitalization(IncorrectCapitalization)
+  , SearchQuery(SearchQuery)
+  , SearchResponse
+  , port
+  )
+
+-- | This is our server root for the 'ServerT' for 'Api'.  We only have two
+-- handlers, 'postStrictSearch' and 'postLaxSearch'.
+serverRoot :: ServerT Api Handler
+serverRoot = postStrictSearch :<|> postLaxSearch :<|> postNoErrSearch
+
+-- | This is the handler for 'Api.ApiStrictSearch'.
+postStrictSearch
+  :: SearchQuery
+  -> Handler (Envelope '[BadSearchTermErr, IncorrectCapitalization] SearchResponse)
+postStrictSearch query =
+  runEnvelopeT $ do
+    res <- checkQueryInDb query
+    relaxEnvT $ doubleCheckCapitalization query
+    doubleCheckCapitalizationGeneral query
+    pure res
+
+-- | Check that the input 'SearchQuery' is in the DB.  (The DB is just a list
+-- of greetings.)
+--
+-- If the input 'SearchQuery' is in the DB, return the string @"greeting"@.
+-- Otherwise, throw an envelope error 'BadSearchTermErr'.
+--
+-- Note that this function says that it might also return an
+-- 'IncorrectCapitalization' error, but it doesn't actually.  This is just for
+-- demonstration.
+--
+-- Also note that our underlying Monad here is 'Handler'.
+checkQueryInDb
+  :: SearchQuery
+  -> EnvelopeT '[BadSearchTermErr, IncorrectCapitalization] Handler SearchResponse
+checkQueryInDb (SearchQuery query) = do
+  liftIO $ putStrLn "querying DB..."
+  let lowerQuery = fmap toLower query
+  case lowerQuery `elem` ["hello", "goodbye", "goodnight"] of
+    True -> pure "greeting"
+    False -> throwErrEnvT BadSearchTermErr
+
+-- | Check the first letter of 'SearchQuery' to make sure that it is lowercase.
+--
+-- If it is not lowercase, throw 'IncorrectCapitalization'.
+--
+-- Note that 'relaxEnvT' needs to be called on the result of this to use it in
+-- do notation with the above 'checkQueryInDb'.  This is because the result of
+-- this is technically a different monad than the result of 'checkQueryInDb',
+-- because the error types are different.
+--
+-- Also note that since we only use 'MonadIO' for this, our underlying monad is
+-- polymorphic.  We don't specialize it to 'Handler'.
+doubleCheckCapitalization
+  :: MonadIO m => SearchQuery -> EnvelopeT '[IncorrectCapitalization] m ()
+doubleCheckCapitalization (SearchQuery []) = liftIO $ putStrLn "search query empty"
+doubleCheckCapitalization (SearchQuery (q:query)) =
+  if toLower q == q
+    then pure ()
+    else throwErrEnvT IncorrectCapitalization
+
+-- | This is just like 'doubleCheckCapitalization' above, but we use the
+-- 'IsMember' constraint to make this function more general.  In
+-- 'postStrictSearch', you can see that we don't have to call 'relaxEnvT' when
+-- using this function.
+doubleCheckCapitalizationGeneral
+  :: IsMember IncorrectCapitalization es => SearchQuery -> EnvelopeT es Handler ()
+doubleCheckCapitalizationGeneral _ = throwErrEnvT IncorrectCapitalization
+
+-- | This doesn't do anything interesting.
+--
+-- See 'postLaxSearch' in @./Server.hs@ for an example using 'Envelope'.
+postLaxSearch
+  :: SearchQuery
+  -> Handler (Envelope '[BadSearchTermErr] SearchResponse)
+postLaxSearch _ = pureSuccEnvelope "good"
+
+-- | This doesn't do anything interesting.
+--
+-- See 'postNoErrSearch' in @./Server.hs@ for an example using 'Envelope'.
+postNoErrSearch :: SearchQuery -> Handler (Envelope '[] SearchResponse)
+postNoErrSearch (SearchQuery _) = pureSuccEnvelope "good"
+
+-- | Create a WAI 'Application'.
+app :: Application
+app = serve (Proxy :: Proxy Api) serverRoot
+
+-- | Run the WAI 'Application' using 'run' on the port defined by 'port'.
+main :: IO ()
+main = run port app

--- a/servant-checked-exceptions/servant-checked-exceptions.cabal
+++ b/servant-checked-exceptions/servant-checked-exceptions.cabal
@@ -85,6 +85,28 @@ executable servant-checked-exceptions-example-server
   else
     buildable:         False
 
+executable servant-checked-exceptions-example-envelopet
+  main-is:             EnvelopeT.hs
+  other-modules:       Api
+  hs-source-dirs:      example
+  build-depends:       base
+                     , aeson
+                     , http-api-data
+                     , http-types
+                     , servant
+                     , servant-checked-exceptions
+                     , servant-server
+                     , text
+                     , wai
+                     , warp
+  default-language:    Haskell2010
+  ghc-options:         -Wall -threaded -rtsopts -with-rtsopts=-N
+
+  if flag(buildexample)
+    buildable:         True
+  else
+    buildable:         False
+
 test-suite servant-checked-exceptions-test
   type:                exitcode-stdio-1.0
   main-is:             Spec.hs

--- a/servant-checked-exceptions/servant-checked-exceptions.cabal
+++ b/servant-checked-exceptions/servant-checked-exceptions.cabal
@@ -1,5 +1,5 @@
 name:                servant-checked-exceptions
-version:             2.1.0.0
+version:             2.2.0.0
 synopsis:            Checked exceptions for Servant APIs.
 description:         Please see <https://github.com/cdepillabout/servant-checked-exceptions#readme README.md>.
 homepage:            https://github.com/cdepillabout/servant-checked-exceptions

--- a/servant-checked-exceptions/servant-checked-exceptions.cabal
+++ b/servant-checked-exceptions/servant-checked-exceptions.cabal
@@ -35,7 +35,7 @@ library
                      , servant-client-core >= 0.16
                      , servant-server >= 0.16
                      , wai
-                     , world-peace
+                     , world-peace >= 1.0.0.0
   default-language:    Haskell2010
   ghc-options:         -Wall -fwarn-incomplete-uni-patterns -fwarn-incomplete-record-updates -fwarn-monomorphism-restriction
   other-extensions:    QuasiQuotes

--- a/stack.yaml
+++ b/stack.yaml
@@ -11,7 +11,8 @@ packages:
 - 'servant-checked-exceptions-core'
 
 # Packages to be pulled from upstream that are not in the resolver (e.g., acme-missiles-0.3)
-extra-deps: []
+extra-deps:
+    - ../world-peace
 
 # Override default flag values for local packages and extra-deps
 flags: {}

--- a/stack.yaml
+++ b/stack.yaml
@@ -43,3 +43,7 @@ extra-package-dbs: []
 # This has been disabled because of the following exchange:
 # https://github.com/cdepillabout/pretty-simple/pull/1#issuecomment-272706215
 #pvp-bounds: both
+
+nix:
+  packages:
+    - zlib

--- a/stack.yaml
+++ b/stack.yaml
@@ -12,7 +12,7 @@ packages:
 
 # Packages to be pulled from upstream that are not in the resolver (e.g., acme-missiles-0.3)
 extra-deps:
-    - ../world-peace
+    - world-peace-1.0.0.0
 
 # Override default flag values for local packages and extra-deps
 flags: {}

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,6 +1,8 @@
 # For more information, see: http://docs.haskellstack.org/en/stable/yaml_configuration.html
 
 # Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
+#
+# nightly is used here so we get servant-0.16.
 resolver: nightly-2019-04-05
 
 # Local packages, usually specified by relative directory name


### PR DESCRIPTION
This PR adds the `EnvelopeT` monad transformer.

An example of using this can be found in the following file:

https://github.com/cdepillabout/servant-checked-exceptions/blob/91a8eb8d5d505adff6df85c496c174ac1fd4fc2f/servant-checked-exceptions/example/EnvelopeT.hs

This also adds a few more combinators for `Envelope`.

This is for #3.  Note that this doesn't add an mtl-like `MonadEnvelope` type class.