### PR TITLE
Relax unnecessary kind constraint.

### DIFF
--- a/servant-checked-exceptions-core/src/Servant/Checked/Exceptions/Internal/Servant/API.hs
+++ b/servant-checked-exceptions-core/src/Servant/Checked/Exceptions/Internal/Servant/API.hs
@@ -34,7 +34,7 @@ import Servant.Checked.Exceptions.Internal.Util (Snoc)
 --
 -- >>> import Servant.API (Get, JSON, (:>))
 -- >>> type API = Throws String :> Get '[JSON] Int
-data Throws (e :: *)
+data Throws e
 
 -- | 'NoThrow' is used to indicate that an API will not throw an error, but
 -- that it will still return a response wrapped in a


### PR DESCRIPTION
If you don't have this constraint, you can do fun things like using the integer literals of status codes as error types.

Whether one thinks that's a good idea or not, the proposed change should be harmless.